### PR TITLE
Creates a parallel publishing.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Pull images from Docker
         run: |
           # Read the Dockerfile and extract the common images
-          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
+          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' $GITHUB_WORKSPACE/Dockerfile)
           # Loop through the images and pull them
           for image in $common_images; do
             (
@@ -72,8 +72,9 @@ jobs:
               docker save -o "$tarball" "$image_name:${!variable}"
               (
                 flock -n 200
-                echo "$tarball" >> .docker-tarballs
-              ) 200>.docker-tarballs-lock
+                echo "Saving $tarball to file."
+                echo "$tarball" >> $GITHUB_WORKSPACE/.docker-tarballs
+              ) 200>$GITHUB_WORKSPACE/.docker-tarballs-lock
             ) &
           done
           wait
@@ -81,14 +82,15 @@ jobs:
       - name: Upload file
         uses: actions/upload-artifact@v4
         with:
-          name: .docker-tarballs
-          path: .docker-tarballs
+          name: Docker Tarballs
+          path: $GITHUB_WORKSPACE/.docker-tarballs
+          if-no-files-found: error
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4
         with:
           path: |
-            $(cat .docker-tarballs)
+            $(cat $GITHUB_WORKSPACE/.docker-tarballs)
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -162,7 +164,8 @@ jobs:
       - name: Download file
         uses: actions/download-artifact@v4
         with:
-          name: .docker-tarballs
+          name: Docker Tarballs
+          path: $GITHUB_WORKSPACE/.docker-tarballs
 
       # Prepare the cache to receive Buildx images downloaded.
       # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
@@ -170,14 +173,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            $(cat .docker-tarballs)
+            $(cat $GITHUB_WORKSPACE/.docker-tarballs)
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
       - name: Load the previous Docker images
         run: |
-          for tarball in $(cat .docker-tarballs); do
+          for tarball in $(cat $GITHUB_WORKSPACE/.docker-tarballs); do
             docker load -i "$tarball"
           done
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,9 +61,8 @@ jobs:
       - name: Pull images from Docker
         run: |
           mkdir docker_images
-          cd docker_images
           # Read the Dockerfile and extract the common images
-          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' ../Dockerfile)
+          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
           # Loop through the images and pull them
           for image in $common_images; do
             (

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           files=$(ls -1 "docker_images" | tr '\n' ' ')
           echo "Saving these files into output: $files"
-          echo "docker-tarballs=$(ls -1 "$files" | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "docker-tarballs=$files" >> $GITHUB_OUTPUT
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,7 +63,7 @@ jobs:
           mkdir docker_images
           cd docker_images
           # Read the Dockerfile and extract the common images
-          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
+          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' ../Dockerfile)
           # Loop through the images and pull them
           for image in $common_images; do
             (

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Load the previous Docker images
         run: |
-          for tarball in *_cached.tar; do
+          for tarball in $(cat .docker-tarballs); do
             docker load -i "$tarball"
           done
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,6 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Pull images from Docker
-        id: get-docker-tarballs
         run: |
           mkdir docker_images
           cd docker_images

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
           for image in $common_images; do
             # Extract the image name and variable part
             image_name=$(echo $image | cut -d':' -f1)
-            variable=$(echo $image | cut -d':' -f2 | tr -d '$')
+            variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
             # Pull the image using the environment variable
             docker pull "$image_name:${!variable}"
             tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,7 +108,6 @@ jobs:
 
       - name: Ensure our PHP Versions file exists.
         run: |
-          ls -lan ./
           if [ ! -f "${{ env.PHP_VERSIONS_FILE }}" ]; then
             echo "PHP Versions file does not exist. Exiting."
             exit 1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,9 +67,9 @@ jobs:
               image_name=$(echo $image | cut -d':' -f1)
               variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
               # Pull the image using the environment variable
-              # docker pull "$image_name:${!variable}"
+              docker pull "$image_name:${!variable}"
               tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
-              # docker save -o "$tarball" "$image_name:${!variable}"
+              docker save -o "$tarball" "$image_name:${!variable}"
               (
                 flock -e 200
                 echo "Saving $tarball to file."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           if [ -d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
             echo "These are the Docker tarballs to cache:"
-            ls -1 docker_images
+            echo $(ls -1 "docker_images" | awk '{print "docker_images/" $0}' | tr '\n' ' ')
           else
             echo "No tarballs were detected, failing."
             exit 1
@@ -90,7 +90,7 @@ jobs:
       - name: Output the Docker Images locations
         id: get-docker-tarballs
         run: |
-          files=$(ls -1 "docker_images" | tr '\n' ' ')
+          files=$(ls -1 "docker_images" | awk '{print "docker_images/" $0}' | tr '\n' ' ')
           echo "Saving these files into output: $files"
           echo "docker-tarballs=$files" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           if [ -d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
             echo "These are the Docker tarballs to cache:"
-            ls -l docker_images
+            ls -1 docker_images
           else
             echo "No tarballs were detected, failing."
             exit 1
@@ -89,13 +89,16 @@ jobs:
 
       - name: Output the Docker Images locations
         id: get-docker-tarballs
-        run: echo "docker-tarballs=$(ls -1 "docker_images" | tr '\n' ' ')" >> $GITHUB_OUTPUT
+        run: |
+          files=$(ls -1 "docker_images" | tr '\n' ' ')
+          echo "Saving these files into output: $files"
+          echo "docker-tarballs=$(ls -1 "$files" | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4
         with:
           path: |
-            ${{ steps.docker-tarballs.outputs.docker-tarballs }}
+            ${{ steps.get-docker-tarballs.outputs.docker-tarballs }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -172,14 +175,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ steps.docker-tarballs.outputs.docker-tarballs }}
+            ${{ steps.get-docker-tarballs.outputs.docker-tarballs }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
       - name: Load the previous Docker images
         run: |
-          for tarball in "${{ steps.docker-tarballs.outputs.docker-tarballs }}"; do
+          for tarball in "${{ steps.get-docker-tarballs.outputs.docker-tarballs }}"; do
             docker load -i "$tarball"
           done
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -165,7 +165,8 @@ jobs:
       - name: Retrieve cached Docker layers
         uses: actions/cache@v4
         with:
-          path: ${{ steps.docker-tarballs.outputs.docker-tarballs }}
+          path: |
+            ${{ steps.docker-tarballs.outputs.docker-tarballs }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,15 +62,22 @@ jobs:
           common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
           # Loop through the images and pull them
           for image in $common_images; do
-            # Extract the image name and variable part
-            image_name=$(echo $image | cut -d':' -f1)
-            variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
-            # Pull the image using the environment variable
-            docker pull "$image_name:${!variable}"
-            tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
-            docker save -o "$tarball" "$image_name:${!variable}"
-            echo "$tarball" >> .docker-tarballs
+            (
+              # Extract the image name and variable part
+              image_name=$(echo $image | cut -d':' -f1)
+              variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
+              # Pull the image using the environment variable
+              docker pull "$image_name:${!variable}"
+              tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
+              docker save -o "$tarball" "$image_name:${!variable}"
+              (
+                flock -n 200
+                echo "$tarball" >> .docker-tarballs
+              ) 200>.docker-tarballs-lock
+              echo "$tarball" >> .docker-tarballs
+            ) &
           done
+          wait
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,7 +71,7 @@ jobs:
               tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
               # docker save -o "$tarball" "$image_name:${!variable}"
               (
-                flock -n 200
+                flock -e 200
                 echo "Saving $tarball to file."
                 echo "$tarball" >> .docker-tarballs
               ) 200>.docker-tarballs-lock
@@ -86,6 +86,8 @@ jobs:
         with:
           name: Docker Tarballs
           path: .docker-tarballs
+          overwrite: true
+          include-hidden-files: true
           if-no-files-found: error
 
       - name: Move the cached images to the cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,12 +9,78 @@ on:
     branches: [ "1.x" ]
 
 env:
+  DOCKER_BUILDKIT: 1
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
   PHP_VERSIONS_FILE: "scripts/conf/versions.yml"
   PHP_VERSION_MIN: "5.6"
+  COMPOSER_VERSION: "latest"
+  NODE_VERSION: "latest"
+  FRANKENPHP_VERSION: "latest"
+  RR_VERSION: "latest"
+  DENO_VERSION: "latest"
+  BUN_VERSION: "latest"
 
 jobs:
+  cache_images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      # Set up BuildKit so we can pull the images from Docker
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Pull images from Docker
+        run: |
+          # Read the Dockerfile and extract the common images
+          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
+          # Loop through the images and pull them
+          for image in $common_images; do
+            # Extract the image name and variable part
+            image_name=$(echo $image | cut -d':' -f1)
+            variable=$(echo $image | cut -d':' -f2 | tr -d '$')
+            # Pull the image using the environment variable
+            docker pull "$image_name:${!variable}"
+            tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
+            docker save -o "$tarball" "$image_name:${!variable}"
+            echo "$tarball" >> .docker-tarballs
+          done
+
+      - name: Move the cached images to the cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            $(cat .docker-tarballs)
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
   setup-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -49,7 +115,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 1
+      # Not needed because the cached images run brrrr...
+      # max-parallel: 1
       matrix:
         version: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 
@@ -85,10 +152,17 @@ jobs:
       - name: Retrieve cached Docker layers
         uses: actions/cache@v4
         with:
-          path: /tmp/.buildx-cache
+          path: |
+            $(cat .docker-tarballs)
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+
+      - name: Load the previous Docker images
+        run: |
+          for tarball in *_cached.tar; do
+            docker load -i "$tarball"
+          done
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   cache_images:
     runs-on: ubuntu-latest
+    outputs:
+      docker-tarballs: ${{ steps.get-docker-tarballs.outputs.docker-tarballs }}
 
     steps:
       - name: Check out code
@@ -57,6 +59,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Pull images from Docker
+        id: get-docker-tarballs
         run: |
           # Read the Dockerfile and extract the common images
           common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
@@ -80,21 +83,13 @@ jobs:
           wait
           echo "These are the contents of the docker tarballs:"
           cat .docker-tarballs
-
-      - name: Upload file
-        uses: actions/upload-artifact@v4
-        with:
-          name: Docker Tarballs
-          path: .docker-tarballs
-          overwrite: true
-          include-hidden-files: true
-          if-no-files-found: error
+          echo "docker-tarballs=$(cat .docker-tarballs)" >> $GITHUB_OUTPUT
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4
         with:
           path: |
-            $(cat .docker-tarballs)
+            ${{ steps.docker-tarballs.outputs.docker-tarballs }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -165,25 +160,19 @@ jobs:
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 
-      - name: Download file
-        uses: actions/download-artifact@v4
-        with:
-          name: Docker Tarballs
-
       # Prepare the cache to receive Buildx images downloaded.
       # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
       - name: Retrieve cached Docker layers
         uses: actions/cache@v4
         with:
-          path: |
-            $(cat .docker-tarballs)
+          path: ${{ steps.docker-tarballs.outputs.docker-tarballs }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
       - name: Load the previous Docker images
         run: |
-          for tarball in $(cat .docker-tarballs); do
+          for tarball in "${{ steps.docker-tarballs.outputs.docker-tarballs }}"; do
             docker load -i "$tarball"
           done
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,6 +58,17 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      # Reuse the cache for this PR specifically
+      # For that, we will use the PR number as cache to hit it more constantly.
+      - name: Restore the images from the cache for PR purposes
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ./docker-images
+          key: ${{ runner.os }}-docker-images-${{ github.event.pull_request.number }}
+          restore-keys: |
+            ${{ runner.os }}-docker-images-
+
       - name: Pull images from Docker
         run: |
           mkdir docker_images
@@ -66,22 +77,24 @@ jobs:
           # Loop through the images and pull them
           for image in $common_images; do
             (
-              # Extract the image name and variable part
+              # Extract the image name, variable part, and set the tarball location
               image_name=$(echo $image | cut -d':' -f1)
               variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
-              # Pull the image using the environment variable
-              docker pull "$image_name:${!variable}"
-              tarball=docker_images/$(basename "$image_name" | sed 's/:/-/g')_cached.tar
-              docker save -o "$tarball" "$image_name:${!variable}"
+              tarball="docker-images/$(basename "$image_name" | sed 's/:/-/g')_cached.tar"
+              # Pull the image if it doesn't exists its cached version
+              if [ ! -f "$tarball" ]; then
+                docker pull "$image_name:${!variable}"
+                docker save -o "$tarball" "$image_name:${!variable}"
+              fi
             ) &
           done
           wait
 
-      - name: Check images were pulled from Docker
+      - name: Check images pulled from Docker
         run: |
-          if [ -d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
+          if [ -d "docker-images" ] && [ "$(ls -A docker-images)" ]; then
             echo "These are the Docker tarballs to cache:"
-            ls -1 "docker_images"
+            ls -1 "docker-images"
           else
             echo "No tarballs were detected, failing."
             exit 1
@@ -92,19 +105,8 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
-          path: ./docker_images
+          path: ./docker-images
           key: ${{ runner.os }}-docker-images-${{ github.sha }}
-
-      # Don't renew the cache if this is a PR
-      # For that, we will use the PR number as cache to hit it more constantly.
-      - name: Restore the images from the cache for PR purposes
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@v4
-        with:
-          path: ./docker_images
-          key: ${{ runner.os }}-docker-images-${{ github.event.pull_request.number }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
 
   setup-matrix:
     needs: cache_images
@@ -170,39 +172,28 @@ jobs:
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 
-      # Prepare the cache to receive Buildx images downloaded.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      - name: Retrieve cached Docker layers
-        if: github.event_name != 'pull_request'
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      # Prepare the cache to receive Buildx images downloaded.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      - name: Retrieve cached Docker layers
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.event.pull_request.number }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Restore cached Docker Images
+        if: github.event_name != 'pull_request'
         uses: actions/cache/restore@v4
         with:
-          path: ./docker_images
+          path: ./docker-images
           key: ${{ runner.os }}-docker-images-${{ github.sha }}
 
+      # If this is a PR, we will just restore the images from the PR Number.
+      - name: Restore cached Docker Images for the Pull Request
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: ./docker-images
+          key: ${{ runner.os }}-docker-images-${{ github.event.pull_request.number }}
+
+      # Load each cached image to Docker in parallel because we are cool.
       - name: Load the Docker images into BuildKit
         run: |
-          for tarball in docker_images/*; do
-            docker load -i "$tarball"
+          for tarball in docker-images/*; do
+            docker load -i "$tarball" &
           done
+          wait
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -261,19 +252,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.version }}
-
-      # Temp fix
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache to reachable directory
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,10 +74,15 @@ jobs:
                 flock -n 200
                 echo "$tarball" >> .docker-tarballs
               ) 200>.docker-tarballs-lock
-              echo "$tarball" >> .docker-tarballs
             ) &
           done
           wait
+
+      - name: Upload file
+        uses: actions/upload-artifact@v4
+        with:
+          name: .docker-tarballs
+          path: .docker-tarballs
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4
@@ -154,6 +159,11 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
+
+      - name: Download file
+        uses: actions/download-artifact@v4
+        with:
+          name: .docker-tarballs
 
       # Prepare the cache to receive Buildx images downloaded.
       # https://docs.docker.com/build/ci/github-actions/cache/#local-cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,6 +82,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
   setup-matrix:
+    needs: cache_images
     runs-on: ubuntu-latest
     outputs:
       php-version-map-json: ${{ steps.get-php-versions.outputs.php-version-map-json }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Pull images from Docker
         run: |
-          mkdir docker_images
+          mkdir docker-images
           # Read the Dockerfile and extract the common images
           common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
           # Loop through the images and pull them

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,10 +79,11 @@ jobs:
 
       - name: Check images were pulled from Docker
         run: |
-          if [ -f ".docker-tarballs" && -n "$(sed 's/^[ \t]*//;s/[ \t]*$//' ".docker-tarballs" | sed '/^$/d')" ]; then
+          if [-d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
             echo "These are the Docker tarballs to cache:"
-            cat .docker-tarballs
+            ls -l docker_images
           else
+            echo "No tarballs were detected, failing."
             exit 1
           fi
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 
-      # Login against a Docker registry except on PR
+      # Login against a GitHub Container Registry except on PR
       # https://github.com/docker/login-action
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -48,6 +48,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Login against a Docker Hub except on PR
+      # https://github.com/docker/login-action
       - name: Login to DockerHub
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -85,11 +87,22 @@ jobs:
             exit 1
           fi
 
-      - name: Move the cached images to the cache
+      # Always renew the cache if this is not a PR
+      - name: Renew the images in the cache
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/save@v4
+        with:
+          path: ./docker_images
+          key: ${{ runner.os }}-docker-images-${{ github.sha }}
+
+      # Don't renew the cache if this is a PR
+      # For that, we will use the PR number as cache to hit it more constantly.
+      - name: Restore the images from the cache for PR purposes
+        if: github.event_name == 'pull_request'
         uses: actions/cache@v4
         with:
           path: ./docker_images
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-docker-images-${{ github.event.pull_request.number }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
@@ -127,8 +140,6 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Not needed because the cached images run brrrr...
-      # max-parallel: 1
       matrix:
         version: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 
@@ -162,14 +173,32 @@ jobs:
       # Prepare the cache to receive Buildx images downloaded.
       # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
       - name: Retrieve cached Docker layers
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v4
         with:
-          path: ./docker_images
+          path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Load the previous Docker images
+      # Prepare the cache to receive Buildx images downloaded.
+      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
+      - name: Retrieve cached Docker layers
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.event.pull_request.number }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Restore cached Docker Images
+        uses: actions/cache/restore@v4
+        with:
+          path: ./docker_images
+          key: ${{ runner.os }}-docker-images-${{ github.sha }}
+
+      - name: Load the Docker images into BuildKit
         run: |
           for tarball in docker_images/*; do
             docker load -i "$tarball"
@@ -221,13 +250,6 @@ jobs:
             ${{ steps.check_latest.outputs.is_latest == 'true' && 'type=ref,event=branch' || '' }}
           flavor:
             latest=false
-
-      # Use Google Cloud Docker Hub mirror to avoid Docker pull limit.
-      # https://devtron.ai/blog/dodging-docker-hub-rate-limits-the-ultimate-cheat-code-for-your-ci-cd-pipeline/
-      # - name: Override Docker registry mirror
-      #  run: |
-      #    echo 'DOCKER_OPTS="--registry-mirror=https://mirror.gcr.io"' >> $GITHUB_ENV
-      #    echo 'BUILDKIT_REGISTRY_MIRRORS={"docker.io": {"mirrors": ["https://mirror.gcr.io"]}}' >> $GITHUB_ENV
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Pull images from Docker
         run: |
           # Read the Dockerfile and extract the common images
-          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' $GITHUB_WORKSPACE/Dockerfile)
+          common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
           # Loop through the images and pull them
           for image in $common_images; do
             (
@@ -67,30 +67,32 @@ jobs:
               image_name=$(echo $image | cut -d':' -f1)
               variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
               # Pull the image using the environment variable
-              docker pull "$image_name:${!variable}"
+              # docker pull "$image_name:${!variable}"
               tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
-              docker save -o "$tarball" "$image_name:${!variable}"
+              # docker save -o "$tarball" "$image_name:${!variable}"
               (
                 flock -n 200
                 echo "Saving $tarball to file."
-                echo "$tarball" >> $GITHUB_WORKSPACE/.docker-tarballs
-              ) 200>$GITHUB_WORKSPACE/.docker-tarballs-lock
+                echo "$tarball" >> .docker-tarballs
+              ) 200>.docker-tarballs-lock
             ) &
           done
           wait
+          echo "These are the contents of the docker tarballs:"
+          cat .docker-tarballs
 
       - name: Upload file
         uses: actions/upload-artifact@v4
         with:
           name: Docker Tarballs
-          path: $GITHUB_WORKSPACE/.docker-tarballs
+          path: .docker-tarballs
           if-no-files-found: error
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4
         with:
           path: |
-            $(cat $GITHUB_WORKSPACE/.docker-tarballs)
+            $(cat .docker-tarballs)
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -165,7 +167,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Docker Tarballs
-          path: $GITHUB_WORKSPACE/.docker-tarballs
 
       # Prepare the cache to receive Buildx images downloaded.
       # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
@@ -173,14 +174,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            $(cat $GITHUB_WORKSPACE/.docker-tarballs)
+            $(cat .docker-tarballs)
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
       - name: Load the previous Docker images
         run: |
-          for tarball in $(cat $GITHUB_WORKSPACE/.docker-tarballs); do
+          for tarball in $(cat .docker-tarballs); do
             docker load -i "$tarball"
           done
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,8 +24,6 @@ env:
 jobs:
   cache_images:
     runs-on: ubuntu-latest
-    outputs:
-      docker-tarballs: ${{ steps.get-docker-tarballs.outputs.docker-tarballs }}
 
     steps:
       - name: Check out code
@@ -81,24 +79,16 @@ jobs:
         run: |
           if [ -d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
             echo "These are the Docker tarballs to cache:"
-            echo $(ls -1 "docker_images" | awk '{print "docker_images/" $0}' | tr '\n' ' ')
+            ls -1 "docker_images"
           else
             echo "No tarballs were detected, failing."
             exit 1
           fi
 
-      - name: Output the Docker Images locations
-        id: get-docker-tarballs
-        run: |
-          files=$(ls -1 "docker_images" | awk '{print "docker_images/" $0}' | tr '\n' ' ')
-          echo "Saving these files into output: $files"
-          echo "docker-tarballs=$files" >> $GITHUB_OUTPUT
-
       - name: Move the cached images to the cache
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ steps.get-docker-tarballs.outputs.docker-tarballs }}
+          path: ./docker_images
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -174,15 +164,14 @@ jobs:
       - name: Retrieve cached Docker layers
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ steps.get-docker-tarballs.outputs.docker-tarballs }}
+          path: ./docker_images
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
       - name: Load the previous Docker images
         run: |
-          for tarball in "${{ steps.get-docker-tarballs.outputs.docker-tarballs }}"; do
+          for tarball in docker_images/*; do
             docker load -i "$tarball"
           done
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check images were pulled from Docker
         run: |
-          if [-d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
+          if [ -d "docker_images" ] && [ "$(ls -A docker_images)" ]; then
             echo "These are the Docker tarballs to cache:"
             ls -l docker_images
           else

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Pull images from Docker
         id: get-docker-tarballs
         run: |
+          mkdir docker_images
+          cd docker_images
           # Read the Dockerfile and extract the common images
           common_images=$(awk '/# Common images start/,/# Common images end/ { if ($1 == "FROM") print $2 }' Dockerfile)
           # Loop through the images and pull them
@@ -71,19 +73,24 @@ jobs:
               variable=$(echo $image | sed -n 's/.*:${\([^}]*\)}.*/\1/p')
               # Pull the image using the environment variable
               docker pull "$image_name:${!variable}"
-              tarball=$(basename "$image_name" | sed 's/:/-/g')_cached.tar
+              tarball=docker_images/$(basename "$image_name" | sed 's/:/-/g')_cached.tar
               docker save -o "$tarball" "$image_name:${!variable}"
-              (
-                flock -e 200
-                echo "Saving $tarball to file."
-                echo "$tarball" >> .docker-tarballs
-              ) 200>.docker-tarballs-lock
             ) &
           done
           wait
-          echo "These are the contents of the docker tarballs:"
-          cat .docker-tarballs
-          echo "docker-tarballs=$(cat .docker-tarballs)" >> $GITHUB_OUTPUT
+
+      - name: Check images were pulled from Docker
+        run: |
+          if [ -f ".docker-tarballs" && -n "$(sed 's/^[ \t]*//;s/[ \t]*$//' ".docker-tarballs" | sed '/^$/d')" ]; then
+            echo "These are the Docker tarballs to cache:"
+            cat .docker-tarballs
+          else
+            exit 1
+          fi
+
+      - name: Output the Docker Images locations
+        id: get-docker-tarballs
+        run: echo "docker-tarballs=$(ls -1 "docker_images" | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - name: Move the cached images to the cache
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ ARG DENO_VERSION="latest"
 ARG BUN_VERSION="latest"
 ARG S6_VERSION="latest"
 
+# Common images start
 FROM composer:${COMPOSER_VERSION} AS composer-image
 FROM node:${NODE_VERSION} AS node-image
 FROM dunglas/frankenphp:${FRANKENPHP_VERSION} AS frankenphp-image
 FROM ghcr.io/roadrunner-server/roadrunner:${RR_VERSION} AS roadrunner-image
 FROM denoland/deno:${DENO_VERSION} AS deno-image
 FROM oven/bun:${BUN_VERSION} AS bun-image
+# Common images end
 
 FROM php:${PHP_VERSION}
 

--- a/scripts/get-php-versions.sh
+++ b/scripts/get-php-versions.sh
@@ -40,7 +40,7 @@ PHP_VERSION_MIN=${PHP_VERSION_MIN:-"5.6"}
 # Ensure the directory exists
 mkdir -p ./conf
 
-rm "$PHP_VERSIONS_FILE"
+rm -f "$PHP_VERSIONS_FILE"
 
 # Fetch the JSON data from the URL
 json_data=$(curl -s https://www.php.net/releases/index.php?json)


### PR DESCRIPTION
This basically allows GitHub Actions to build images in parallel by caching _some_ common images manually before building the rest.

These images are retrieved from the lines between `# Common images` of the Dockerfile.